### PR TITLE
⚛️  Support react-native

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "types": "./dist/Spline.d.ts",
   "main": "./dist/react-spline.umd.js",
   "module": "./dist/react-spline.es.js",
+  "react-native": "./dist/react-spline.es.js",
   "exports": {
     ".": {
       "import": "./dist/react-spline.es.js",


### PR DESCRIPTION
Metro doesn't like `require()`s, let's point it to the esmodule