### PR TITLE
Add "types" field to package.json "exports"

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "react-native": "./dist/react-spline.es.js",
   "exports": {
     ".": {
+      "types": "./dist/Spline.d.ts",
       "import": "./dist/react-spline.es.js",
       "require": "./dist/react-spline.cjs.js"
     }


### PR DESCRIPTION
[In TypeScript 4.7](https://devblogs.microsoft.com/typescript/announcing-typescript-4-7/#control-over-module-detection), the `nodenext` and `node16` module resolution options were added to better support native ESM in Node.js. When the `package.json` `"exports"` field exists, however, they require a `"types"` field to exist within each entrypoint, or else types won't be resolved when using one of these module resolution options. 

Currently, using this library with either of those settings throws the following TypeScript error:
```
error TS7016: Could not find a declaration file for module '@splinetool/react-spline'. '/project-path/node_modules/@splinetool/react-spline/dist/react-spline.cjs.js' implicitly has an 'any' type.
  Try `npm i --save-dev @types/splinetool__react-spline` if it exists or add a new declaration (.d.ts) file containing `declare module '@splinetool/react-spline';
  ```
  
 
 This PR fixes this issue by adding the `"types"` field to `"exports"` for the `"./"` entrypoint. The same change is required for `@splinetool/runtime`, but I couldn't find a link to a repository where I could submit the change.