### PR TITLE
Correctly throw Spline errors

### DIFF
--- a/src/Spline.tsx
+++ b/src/Spline.tsx
@@ -58,6 +58,12 @@ const Spline = forwardRef<HTMLDivElement, SplineProps>(
   ) => {
     const canvasRef = useRef<HTMLCanvasElement>(null);
     const [isLoading, setIsLoading] = useState(true);
+    const [error, setError] = useState<Error>();
+
+    // We throw the error so ErrorBoundary can catch it
+    if (error) {
+      throw error;
+    }
 
     // Initialize runtime when component is mounted
     useEffect(() => {
@@ -122,7 +128,9 @@ const Spline = forwardRef<HTMLDivElement, SplineProps>(
           onLoad?.(speApp);
         }
 
-        init();
+        init().catch((err) => {
+          setError(err as Error);
+        });
       }
 
       return () => {


### PR DESCRIPTION
Close #49

Now you can catch Spline errors with ErrorBoundary correctly.

```js
import { ErrorBoundary } from "react-error-boundary";

<ErrorBoundary fallback={<div>Something went wrong</div>}>
  <Spline scene="https://prod.spline.design/6Wq1Q7YGyM-iab9i/scene.splinecode" />
</ErrorBoundary>
```